### PR TITLE
Make GUI check more robust

### DIFF
--- a/distribution/__init__.py
+++ b/distribution/__init__.py
@@ -32,19 +32,9 @@ def hook(txt, editor):
     result = re.sub(r'\[FEN\](.*?)\[\/FEN\]', fen2svg, txt, flags=re.IGNORECASE)
     return result
 
-if sys.executable.endswith('anki') or sys.executable.endswith('anki.exe'):
-    print('anki_fen_vis: executing from ANKI gui')
-
-    # read config
-    from aqt import mw
-    config = mw.addonManager.getConfig(__name__)
-    print(f'anki_fen_vis: config {config}')
-
-    # set hook
-    from aqt import gui_hooks
-    gui_hooks.editor_will_munge_html.append(hook)
-
-elif sys.executable.endswith('python'):
+try:
+    from aqt import mw, gui_hooks
+except ImportError:
     print('anki_fen_vis: executing from command-line')
 
     # read config
@@ -57,7 +47,12 @@ elif sys.executable.endswith('python'):
     with open(fpath_json) as fp:
         config = json.load(fp)
     print(f'config: {config}')
-
 else:
-    print('anki_fen_vis: executing ???')
+    print('anki_fen_vis: executing from ANKI gui')
 
+    # read config
+    config = mw.addonManager.getConfig(__name__)
+    print(f'anki_fen_vis: config {config}')
+
+    # set hook
+    gui_hooks.editor_will_munge_html.append(hook)


### PR DESCRIPTION
The previous check did not work when running anki from aqt wheels, where sys.executable will be the python interpreter and would indeed end with python even though we are running inside gui anki.  It was originally noticed on the Linux/flatpak version[1], and will also be an issue on any other packaged version running from wheels such as the Arch Linux AUR or Alpine Linux packages. This made the add-on completely non-functional.


In addition, the check did not work for the command line when calling from a version python binary like python3 or python3.12 e.g. under Debian-based Linux (e.g. Ubuntu) without the python-is-python3 package installed.

[1] https://github.com/flathub/net.ankiweb.Anki/issues/187

Close: https://github.com/lwerdna/anki-fen-vis/issues/4